### PR TITLE
guideposts: fix icon position

### DIFF
--- a/js/guideposts.js
+++ b/js/guideposts.js
@@ -31,7 +31,9 @@ osmcz.guideposts = function(map, baseLayers, overlays, controls) {
     var markers = L.markerClusterGroup({code: 'G'});
 
     var guidepost_icon = L.icon({
-      iconUrl: "img/guidepost.png"
+      iconUrl: "img/guidepost.png",
+      iconSize: [48, 48],
+      iconAnchor: [23, 45]
     });
 
     var commons_icon;


### PR DESCRIPTION
Predtim byla ikonka rozcestniku centrovana na levy horni roh. Nyni je centrovana na intuitivnejsi prostredek spodni casti (tam kde zacina sloupek rozcestniku). Je daleko lepe z mapy videt, kde je skutecna pozice rozcestniku.
