### PR TITLE
Partial fix for issue #133.

### DIFF
--- a/js/poi-popup.js
+++ b/js/poi-popup.js
@@ -234,7 +234,11 @@ osmcz.poiPopup.getHtml = function (feature, icon, embedded = false) {
     };
 
     section(name, 'Další jména:', true);
-    tpl = tpl.concat(osmcz.openingHoursService.getHtml(openingHours));
+    try {
+        tpl = tpl.concat(osmcz.openingHoursService.getHtml(openingHours));
+    } catch (err) {
+        tpl.push("<b>opening_hours</b> = " + openingHours + "<br> <em>(Nepodařilo se naparsovat: "+err+")</em>");
+    }
     section(payment, 'Možnosti platby:');
     section(contact, 'Kontakty:');
     section(building, 'Budova:');


### PR DESCRIPTION
This ensures that opening hours will be displayed even if they are not parsed
properly, as the original tag value.
