### PR TITLE
syntax: Ensure valid HTML/JS code compatible with IE

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,10 +284,12 @@
     </div>
     <!-- /container -->
 
+    <!-- container -->
     <!--
     <div class="container">
         <h1>Normální stránka</h1>
     </div>
+    -->
     <!-- /container -->
 </div>
 <!-- /main -->
@@ -304,7 +306,7 @@
 <script src="https://getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
 
 
-<!-- ------------ vendor ------------ -->
+<!-- ============ vendor ============ -->
 <!-- leaflet -->
 <link rel="stylesheet" href="https://cdn.rawgit.com/Leaflet/Leaflet/v0.7.3/dist/leaflet.css"/>
 <script src="https://cdn.rawgit.com/Leaflet/Leaflet/v0.7.3/dist/leaflet.js"></script>
@@ -352,9 +354,9 @@
 <script type="text/javascript" src="lib/exif.js"></script>
 
 
-<!-- ------------ /vendor ------------ -->
+<!-- ============ /vendor ============ -->
 
-<!-- ------------ app ------------ -->
+<!-- ============ app ============ -->
 <link href="css/map-style.css" rel="stylesheet">
 
 <script src="js/lib-gps-formats-convert.js"></script>
@@ -368,7 +370,7 @@
 <script src="js/poi-popup.js"></script>
 <script src="js/active-layer.js"></script>
 <script src="js/osmcz.js"></script>
-<!-- ------------ /app ------------ -->
+<!-- ============ /app ============ -->
 
 
 <div id="fb-root"></div>

--- a/js/poi-popup.js
+++ b/js/poi-popup.js
@@ -107,7 +107,7 @@ osmcz.poiPopup.setUrl = function (p) {
 
 
 // ------- POI panel template  -------
-osmcz.poiPopup.getHtml = function (feature, icon, embedded = false) {
+osmcz.poiPopup.getHtml = function (feature, icon, embedded) {
 
     //TODO refactor
 


### PR DESCRIPTION
Currently, openstreetmap.cz is broken in IE.

HTML comments (at least in the XHTML/pre-HTML5 sense) cannot contain two
consecutive hyphens, those can appear only as a terminator. And comments
definitely cannot be nested.

IE does not support default JS arguments. However, having a default
value of `= false` is practically redundant, since the otherwise-default
`undefined` is falsy (unless you write `if (arg === false)` instead of
`if (!arg)`).
