### PR TITLE
js/TileLayer.GeoJSON.js - fix reset on zoom

### DIFF
--- a/js/TileLayer.GeoJSON.js
+++ b/js/TileLayer.GeoJSON.js
@@ -37,8 +37,8 @@ L.TileLayer.Ajax = L.TileLayer.extend({
         req.open('GET', this.getTileUrl(tilePoint), true);
         req.send();
     },
-    _reset: function () {
-        L.TileLayer.prototype._reset.apply(this, arguments);
+    _resetView: function () {
+        L.TileLayer.prototype._resetView.apply(this, arguments);
         for (var i = 0; i < this._requests.length; i++) {
             this._requests[i].abort();
         }
@@ -72,11 +72,12 @@ L.TileLayer.GeoJSON = L.TileLayer.Ajax.extend({
         map.removeLayer(this.geojsonLayer);
         L.TileLayer.Ajax.prototype.onRemove.call(this, map);
     },
-    _reset: function () {
+    _resetView: function () {
         this.geojsonLayer.clearLayers();
+        this._removeTilesAtZoom(this._map.getZoom());
         this._keyLayers = {};
         this._removeOldClipPaths();
-        L.TileLayer.Ajax.prototype._reset.apply(this, arguments);
+        L.TileLayer.Ajax.prototype._resetView.apply(this, arguments);
     },
 
     // Remove clip path elements from other earlier zoom levels

--- a/js/layers.js
+++ b/js/layers.js
@@ -11,6 +11,7 @@ osmcz.layers = function (map, baseLayers, overlays, controls) {
 
     var mapbox = L.tileLayer('https://{s}.tiles.mapbox.com/v4/mapbox.streets-basic/{z}/{x}/{y}' + retinaSuffix + '.png?access_token=pk.eyJ1IjoiemJ5Y3oiLCJhIjoiRUdkVEMzMCJ9.7eJ3YhCQtbVUET92En5aGA', {
         attribution: osmAttr + ", <a href='https://www.mapbox.com/about/maps/'>Mapbox</a>",
+        code: 'x',
         osmczDefaultLayer: true
     });
 


### PR DESCRIPTION
Oprava názvu funkce `_reset` na `_resetView` a vyčištění dlaždic z aktuálního zoomu. Opět spíš quick fix, ta vrstva TileLayer.GeoJSON by zasloužila větší refaktoring.
Navazuje na #150 